### PR TITLE
decide which name to put in Jira comment based on public git email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.rb

--- a/jiraGitDemLabels.rb
+++ b/jiraGitDemLabels.rb
@@ -27,9 +27,13 @@ post '/payload' do
 		actionUserURLauth = actionUserURL.insert(8,GIT_HUB_TOKEN+':@')
 		actionUserInfo = JSON.parse(RestClient.get(actionUserURLauth))
 		actionUserEmail = actionUserInfo["email"]
-		actionJiraName = actionUserEmail.split('@')[0]
-		actionJiraNameComment = actionJiraName.insert(0, "[~") + "]"
-		
+		if actionUserEmail.split('@')[1] != "thrillist.com"
+			actionUserHTMLURL = push["sender"]["html_url"]
+			actionJiraNameComment = "["+actionUser+"|"+actionUserHTMLURL+"]"
+		else
+			actionJiraName = actionUserEmail.split('@')[0]
+			actionJiraNameComment = actionJiraName.insert(0, "[~") + "]"
+		end
 		#Loop through all of the tickets in the PR title
 		#Decide what to do to each ticket depending on what labels the PR has
 		i = 0;


### PR DESCRIPTION
if the git user has a thrillist email address, we know that everything before the @ will match the Jira name - so we can include his jira name in the comment. if the user doesnt have the thrillist email address in the public profile, default to the git user name and link it in the comment
